### PR TITLE
Add Terraform Configuration Files for AWS and GCP Services

### DIFF
--- a/Ashwin_terraform_projects/AWS_terraform/aws_imp_notes.txt
+++ b/Ashwin_terraform_projects/AWS_terraform/aws_imp_notes.txt
@@ -1,0 +1,44 @@
+# AWS Terraform Projects
+
+This repository contains modular and independent Terraform scripts to create essential AWS services. Each directory includes a standalone `main.tf` file to help you provision individual resources easily using the Terraform CLI.
+
+##  Folder Structure
+
+- `ec2/` – Deploy a basic EC2 instance
+- `iam_user/` – Create an IAM user
+- `s3/` – Create an S3 bucket
+- `rds/` – Provision an RDS (MySQL) instance
+- `vpc/` – Create a custom VPC
+- `eks_cluster/` – Deploy an EKS cluster using Terraform AWS Module
+
+##  Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) installed
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed and configured (`aws configure`)
+- AWS IAM credentials with sufficient permissions to create resources
+
+##  How to Use
+
+Each module is self-contained. Just `cd` into the folder and run Terraform commands.
+
+### Example: EC2
+
+```bash
+cd ec2
+terraform init
+terraform plan
+terraform apply
+
+
+## To destroy the EC2 instance later:
+
+terraform destroy
+
+#Important: Edit the main.tf file before running if you need to customize AMI IDs, regions, instance types, etc.
+
+#Notes
+#No variables or backend configuration is used — everything is kept simple and in main.tf.
+#EKS and RDS setups may incur costs — review the plan before applying.
+#Make sure your AWS CLI session has the right permissions and region set.
+
+Thanks - Ashwin - CloudChuck

--- a/Ashwin_terraform_projects/AWS_terraform/ec2/main.tf
+++ b/Ashwin_terraform_projects/AWS_terraform/ec2/main.tf
@@ -1,0 +1,9 @@
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "example" {
+  ami           = "ami-00a929b66ed6e0de6" # Amazon Linux 2 AMI
+  instance_type = "t2.micro"
+}

--- a/Ashwin_terraform_projects/AWS_terraform/eks_cluster/main.tf
+++ b/Ashwin_terraform_projects/AWS_terraform/eks_cluster/main.tf
@@ -1,0 +1,61 @@
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Create VPC
+resource "aws_vpc" "eks_vpc" {
+  cidr_block = "10.0.0.0/16"
+}
+
+# Create Subnets
+resource "aws_subnet" "eks_subnet_a" {
+  vpc_id            = aws_vpc.eks_vpc.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "eks_subnet_b" {
+  vpc_id            = aws_vpc.eks_vpc.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1b"
+}
+
+# Create IAM Role for EKS Cluster
+resource "aws_iam_role" "eks_cluster_role" {
+  name = "eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+# Attach EKS Policy to IAM Role
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+# Create EKS Cluster
+resource "aws_eks_cluster" "example" {
+  name     = "my-eks-cluster"
+  role_arn = aws_iam_role.eks_cluster_role.arn
+
+  vpc_config {
+    subnet_ids = [
+      aws_subnet.eks_subnet_a.id,
+      aws_subnet.eks_subnet_b.id,
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_cluster_policy,
+  ]
+}

--- a/Ashwin_terraform_projects/AWS_terraform/iam_user/main.tf
+++ b/Ashwin_terraform_projects/AWS_terraform/iam_user/main.tf
@@ -1,0 +1,8 @@
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_iam_user" "example" {
+  name = "example-user"
+}

--- a/Ashwin_terraform_projects/AWS_terraform/rds/main.tf
+++ b/Ashwin_terraform_projects/AWS_terraform/rds/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_db_instance" "example" {
+  allocated_storage    = 20
+  engine               = "mysql"
+  engine_version       = "8.0"
+  instance_class       = "db.t3.micro"
+  db_name              = "exampledb"       # Corrected to db_name
+  username             = "admin"
+  password             = "admin1234"
+  skip_final_snapshot  = true
+  identifier           = "example-db-instance"  # Corrected to identifier
+}

--- a/Ashwin_terraform_projects/AWS_terraform/s3/main.tf
+++ b/Ashwin_terraform_projects/AWS_terraform/s3/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "my-unique-bucket-name-ashwin-123"  # Ensure the name follows the S3 bucket naming conventions
+}
+
+resource "aws_s3_bucket_acl" "example_acl" {
+  bucket = aws_s3_bucket.example.bucket
+  acl    = "private"
+}

--- a/Ashwin_terraform_projects/AWS_terraform/vpc/main.tf
+++ b/Ashwin_terraform_projects/AWS_terraform/vpc/main.tf
@@ -1,0 +1,8 @@
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}

--- a/Ashwin_terraform_projects/GCP_terraform/cloud_sql/main.tf
+++ b/Ashwin_terraform_projects/GCP_terraform/cloud_sql/main.tf
@@ -1,0 +1,15 @@
+provider "google" {
+  project = "ashwin-terraform-projectid"
+  region  = "us-central1"
+}
+
+resource "google_sql_database_instance" "example" {
+  name                 = "example-db"
+  database_version     = "MYSQL_8_0"
+  region               = "us-central1"
+  deletion_protection  = false   # 👈 This allows Terraform to destroy the instance later
+
+  settings {
+    tier = "db-f1-micro"
+  }
+}

--- a/Ashwin_terraform_projects/GCP_terraform/cloud_storage/main.tf
+++ b/Ashwin_terraform_projects/GCP_terraform/cloud_storage/main.tf
@@ -1,0 +1,10 @@
+
+provider "google" {
+  project = "ashwin-terraform-projectid"
+  region  = "us-central1"
+}
+
+resource "google_storage_bucket" "example" {
+  name     = "my-unique-gcs-bucket-12345678"
+  location = "US"
+}

--- a/Ashwin_terraform_projects/GCP_terraform/compute_engine/main.tf
+++ b/Ashwin_terraform_projects/GCP_terraform/compute_engine/main.tf
@@ -1,0 +1,22 @@
+
+provider "google" {
+  project = "ashwin-terraform-projectid"
+  region  = "us-central1"
+}
+
+resource "google_compute_instance" "example" {
+  name         = "vm-instance"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+}

--- a/Ashwin_terraform_projects/GCP_terraform/gcp_imp_notes.txt
+++ b/Ashwin_terraform_projects/GCP_terraform/gcp_imp_notes.txt
@@ -1,0 +1,63 @@
+
+# GCP Terraform Projects
+
+This folder includes standalone Terraform configuration files to help you provision popular Google Cloud services. Each module lives in its own directory and is completely self-contained with a `main.tf`.
+
+##  Folder Structure
+
+- `compute_engine/` – Launch a VM instance on GCE
+- `iam_user/` – Create a GCP service account (IAM user)
+- `cloud_storage/` – Create a Cloud Storage bucket
+- `cloud_sql/` – Launch a Cloud SQL (MySQL) instance
+- `vpc/` – Create a custom VPC
+- `gke_cluster/` – Deploy a Kubernetes cluster using GKE
+
+##  Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads)
+- [Google Cloud SDK (gcloud)](https://cloud.google.com/sdk/docs/install)
+- A GCP project with billing enabled
+- Service account with `Editor` permissions
+- Required API are enabled
+- Project id need to replaced with your project id
+
+## API enable cmd after created new project in gcp
+
+gcloud config set project your-gcp-project-id
+gcloud services enable compute.googleapis.com
+gcloud services enable container.googleapis.com
+gcloud services enable sqladmin.googleapis.com
+
+
+## First-Time Setup
+
+```bash
+
+
+IMP POWER SHELL cmd
+$env:GOOGLE_APPLICATION_CREDENTIALS="C:/Users/91750/Downloads/service-account.json"
+
+note required 
+gcloud auth login
+gcloud config set project your-project-id
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your-service-account.json"
+
+
+##🚀 How to Use Navigate into any service folder and run:
+
+terraform init
+terraform plan
+terraform apply
+
+# To destroy resources:
+terraform destroy
+
+
+## Important: Replace placeholders like your-gcp-project-id in the main.tf before using.
+
+### Notes
+#No variables or backend state — direct .tf files only.
+#Designed for demo, learning, and personal project usage.
+#GKE and Cloud SQL resources may incur charges — review terraform plan output carefully.
+
+Thanks Ashwin - CloudChuck

--- a/Ashwin_terraform_projects/GCP_terraform/gke_cluster/main.tf
+++ b/Ashwin_terraform_projects/GCP_terraform/gke_cluster/main.tf
@@ -1,0 +1,16 @@
+
+provider "google" {
+  project = "ashwin-terraform-projectid"
+  region  = "us-central1"
+}
+
+resource "google_container_cluster" "example" {
+  name     = "example-gke"
+  location = "us-central1"
+
+  initial_node_count = 1
+  deletion_protection = false
+  node_config {
+    machine_type = "e2-medium"
+  }
+}

--- a/Ashwin_terraform_projects/GCP_terraform/iam_user/main.tf
+++ b/Ashwin_terraform_projects/GCP_terraform/iam_user/main.tf
@@ -1,0 +1,9 @@
+
+provider "google" {
+  project = "ashwin-terraform-projectid"
+}
+
+resource "google_service_account" "example" {
+  account_id   = "example-user"
+  display_name = "Example User"
+}

--- a/Ashwin_terraform_projects/GCP_terraform/vpc/main.tf
+++ b/Ashwin_terraform_projects/GCP_terraform/vpc/main.tf
@@ -1,0 +1,10 @@
+
+provider "google" {
+  project = "ashwin-terraform-projectid"
+  region  = "us-central1"
+}
+
+resource "google_compute_network" "example" {
+  name                    = "custom-vpc"
+  auto_create_subnetworks = false
+}


### PR DESCRIPTION

This PR includes Terraform `main.tf` files for provisioning and managing AWS and GCP services, such as EC2, VPC, RDS, and Cloud Storage. The configurations are modular, reusable, and designed for independent deployment of cloud resources. 

Thanks,
Ashwin